### PR TITLE
Refactor table function into internal module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ Be sure to add tests for new functions and run them within this file directory:
 jq --run-tests version.test
 ```
 
+To run all tests:
+
+```bash
+find . -name '*.test' -exec jq --run-tests {} \;
+```
+
 Test files may contain comments prefaced with `#` and lines consistenting of:
 
 1. The jq program.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These are handy [jq] modules that can be imported and used in your jq expression
 
 ```bash
 echo '[{"num":1,"desc":"one"},{"num":2,"desc":"two"}]' |
-  jq -r 'include "heaths/table"; table'
+  jq -r 'include "heaths/format"; table'
 ```
 
 ## Install
@@ -28,7 +28,7 @@ The first row is used to identify scalar values' key names used for the header r
 
 ```bash
 echo '[{"num":1,"desc":"one","sib":[0,2]},{"num":2,"desc":"two","sib":[1,3]}]' |
-  jq -r 'include "heaths/table"; table'
+  jq -r 'include "heaths/format"; table'
 ```
 
 ```text
@@ -43,7 +43,7 @@ num     desc
 
 ```bash
 echo '[{"num":1,"desc":"one","sib":[0,2]},{"num":2,"desc":"two","sib":[1,3]}]' |
-  jq -r 'include "heaths/table"; table_rows'
+  jq -r 'include "heaths/format"; table_rows'
 ```
 
 ```text

--- a/format.jq
+++ b/format.jq
@@ -1,0 +1,13 @@
+# Copyright 2025 Heath Stewart.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+module {version: "0.1.0", homepage: "https://github.com/heaths/jq"};
+
+import "./internal/table" as i;
+
+# Formats an array of objects' scalar values to a tab-separated table with a header row containing key names.
+# Usage: echo '[{"foo":"baz","bar":1},{"foo":"qux","bar":2}]' | jq -r 'include "format"; table' | column -t
+def table: i::table | @tsv;
+
+# Formats an array of objects' scalar values to a tab-separated table without a header row
+# Usage: echo '[{"foo":"baz","bar":1},{"foo":"qux","bar":2}]' | jq -r 'include "format"; table_rows' | column -t
+def table_rows: [i::table][1:][] | @tsv;

--- a/format.test
+++ b/format.test
@@ -1,18 +1,18 @@
-import "table" as m; m::table
+import "format" as m; m::table
 [{"n":1,"t":"one"},{"n":2,"t":"two"}]
 "n\tt"
 "1\tone"
 "2\ttwo"
 
-import "table" as m; m::table_rows
+import "format" as m; m::table_rows
 [{"n":1,"t":"one"},{"n":2,"t":"two"}]
 "1\tone"
 "2\ttwo"
 
-import "table" as m; try m::table catch .
+import "format" as m; try m::table catch .
 {"n":1,"t":"one"}
 "expected array, got object"
 
-import "table" as m; try m::table catch .
+import "format" as m; try m::table catch .
 ["string"]
 "expected array, got array of string"

--- a/internal/table.jq
+++ b/internal/table.jq
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 module {version: "0.1.0", homepage: "https://github.com/heaths/jq"};
 
-def _table:
+def table:
   type as $type
   | flatten as $input
   | $input[0]? | type as $subtype
@@ -12,12 +12,3 @@ def _table:
   else
     error("expected array, got \($type)" + if $type == "array" then " of \($subtype)" else "" end)
   end;
-
-# Formats an array of objects' scalar values to a tab-separated table with a header row containing key names.
-# Usage: echo '[{"foo":"baz","bar":1},{"foo":"qux","bar":2}]' | jq -r 'include "table"; table' | column -t
-def table: _table | @tsv;
-
-# Formats an array of objects' scalar values to a tab-separated table without a header row
-# Usage: echo '[{"foo":"baz","bar":1},{"foo":"qux","bar":2}]' | jq -r 'include "table"; table_rows' | column -t
-def table_rows: [_table][1:][] | @tsv;
-


### PR DESCRIPTION
Put the table and table_row formatting functions in a new format module, and move _table to internal/table.jq following convention for Go.
